### PR TITLE
feat: add open, close, toggle methods to the popover component

### DIFF
--- a/demo/app/demo.component.ts
+++ b/demo/app/demo.component.ts
@@ -13,6 +13,7 @@ import { SatPopoverAnchor } from '@sat/popover';
 
     <div class="page-content">
 
+      <!-- BUTTONS -->
       <mat-card>
         <mat-card-title>Click the buttons</mat-card-title>
         <mat-card-content>
@@ -20,8 +21,35 @@ import { SatPopoverAnchor } from '@sat/popover';
           <button mat-raised-button [satPopoverAnchorFor]="popover2">Woo! ←</button>
           <button mat-raised-button [satPopoverAnchorFor]="popover3">Woo! ·</button>
         </mat-card-content>
+
+        <sat-popover #popover1
+            xPosition="after"
+            yPosition="below"
+            [overlapAnchor]="false">
+          <div style="background: lightgray; padding: 48px">
+            Oh, cool
+          </div>
+        </sat-popover>
+
+        <sat-popover #popover2
+            xPosition="before"
+            yPosition="center"
+            [overlapAnchor]="false">
+          <div style="background: lightgray; padding: 48px" class="mat-elevation-z12">
+            Oh, neat
+          </div>
+        </sat-popover>
+
+        <sat-popover #popover3
+            xPosition="center"
+            yPosition="center"
+            [overlapAnchor]="false">
+          <mat-toolbar color="accent" class="mat-elevation-z2">Oh, nifty</mat-toolbar>
+        </sat-popover>
+
       </mat-card>
 
+      <!-- SELECT OPTION -->
       <mat-card>
         <mat-card-title>Select "Fancy"</mat-card-title>
         <mat-card-content>
@@ -37,43 +65,34 @@ import { SatPopoverAnchor } from '@sat/popover';
             </mat-select>
           </mat-form-field>
         </mat-card-content>
+
+        <sat-popover #fancyPopover
+            xPosition="center"
+            yPosition="below">
+          <div style="background: pink; padding: 32px; border-radius: 8px"
+              class="mat-elevation-z4">
+            Quite fancy indeed 🎩
+          </div>
+        </sat-popover>
       </mat-card>
 
+      <!-- PROGRAMMATIC OPEN/CLOSE -->
+      <mat-card>
+        <mat-card-title>Open Programmatically</mat-card-title>
+        <mat-card-content>
+          <div style="margin: 48px; height: 16px; width: 16px; background: black"
+              [satPopoverAnchorFor]="bluePopover">
+          </div>
+        </mat-card-content>
+        <sat-popover #bluePopover>
+          <div style="background: blue; padding: 16px">BLUE!</div>
+        </sat-popover>
+        <mat-card-actions>
+          <button mat-button (click)="bluePopover.open()">Open</button>
+          <button mat-button (click)="bluePopover.close()">Close</button>
+        </mat-card-actions>
+      </mat-card>
     </div>
-
-    <sat-popover #popover1
-        xPosition="after"
-        yPosition="below"
-        [overlapAnchor]="false">
-      <div style="background: lightgray; padding: 48px">
-        Oh, cool
-      </div>
-    </sat-popover>
-
-    <sat-popover #popover2
-        xPosition="before"
-        yPosition="center"
-        [overlapAnchor]="false">
-      <div style="background: lightgray; padding: 48px" class="mat-elevation-z12">
-        Oh, neat
-      </div>
-    </sat-popover>
-
-    <sat-popover #popover3
-        xPosition="center"
-        yPosition="center"
-        [overlapAnchor]="false">
-      <mat-toolbar color="accent" class="mat-elevation-z2">Oh, nifty</mat-toolbar>
-    </sat-popover>
-
-    <sat-popover #fancyPopover
-        xPosition="center"
-        yPosition="below">
-      <div style="background: pink; padding: 32px; border-radius: 8px"
-          class="mat-elevation-z4">
-        Quite fancy indeed 🎩
-      </div>
-    </sat-popover>
   `
 })
 export class DemoComponent {

--- a/demo/app/demo.component.ts
+++ b/demo/app/demo.component.ts
@@ -85,11 +85,12 @@ import { SatPopoverAnchor } from '@sat/popover';
           </div>
         </mat-card-content>
         <sat-popover #bluePopover>
-          <div style="background: blue; padding: 16px">BLUE!</div>
+          <div style="background: lightblue; padding: 16px">BLUE!</div>
         </sat-popover>
         <mat-card-actions>
           <button mat-button (click)="bluePopover.open()">Open</button>
           <button mat-button (click)="bluePopover.close()">Close</button>
+          <button mat-button (click)="bluePopover.toggle()">Toggle</button>
         </mat-card-actions>
       </mat-card>
     </div>

--- a/lib/popover/popover.component.ts
+++ b/lib/popover/popover.component.ts
@@ -15,6 +15,7 @@ import { AnimationEvent } from '@angular/animations';
 import { DOCUMENT } from '@angular/platform-browser';
 import { FocusTrap, FocusTrapFactory } from '@angular/cdk/a11y';
 import { ESCAPE } from '@angular/cdk/keycodes';
+import { Subject } from 'rxjs/Subject';
 
 import { transformPopover } from './popover.animations';
 
@@ -63,6 +64,9 @@ export class SatPopover implements AfterViewInit {
   /** Classes to be added to the popover for setting the correct transform origin. */
   _classList: any = {};
 
+  /** Emits whenever the popover should take some action. */
+  _takeAction = new Subject<'open' | 'close' | 'toggle'>();
+
   /** Reference to the element to build a focus trap around. */
   @ViewChild('focusTrapElement')
   private _focusTrapElement: ElementRef;
@@ -82,8 +86,23 @@ export class SatPopover implements AfterViewInit {
     this._setPositionClasses();
   }
 
+  /** Open this popover. */
+  open(): void {
+    this._takeAction.next('open');
+  }
+
+  /** Close this popover. */
+  close(): void {
+    this._takeAction.next('close');
+  }
+
+  /** Toggle this popover open or closed. */
+  toggle(): void {
+    this._takeAction.next('toggle');
+  }
+
   /** Publicly emit a close event. */
-  emitCloseEvent(): void {
+  _emitCloseEvent(): void {
     this.closed.emit();
   }
 
@@ -91,7 +110,7 @@ export class SatPopover implements AfterViewInit {
   _handleKeydown(event: KeyboardEvent): void {
     if (event.keyCode === ESCAPE) {
       event.stopPropagation();
-      this.emitCloseEvent();
+      this._emitCloseEvent();
     }
   }
 

--- a/tools/rollup-globals.js
+++ b/tools/rollup-globals.js
@@ -14,7 +14,10 @@ const GLOBALS = {
 
   // rxjs globals
   'rxjs/Subject': 'Rx',
+  'rxjs/Observable': 'Rx',
   'rxjs/add/operator/takeUntil': 'Rx.Observable.prototype',
+  'rxjs/add/operator/startWith': 'Rx.Observable.prototype',
+  'rxjs/add/operator/switchMap': 'Rx.Observable.prototype',
 };
 
 module.exports = GLOBALS;

--- a/tools/rollup-globals.js
+++ b/tools/rollup-globals.js
@@ -16,7 +16,6 @@ const GLOBALS = {
   'rxjs/Subject': 'Rx',
   'rxjs/Observable': 'Rx',
   'rxjs/add/operator/takeUntil': 'Rx.Observable.prototype',
-  'rxjs/add/operator/startWith': 'Rx.Observable.prototype',
   'rxjs/add/operator/switchMap': 'Rx.Observable.prototype',
 };
 


### PR DESCRIPTION
Before, users would have to get a hold of the anchor to programmatically toggle the popover, but since they will already have a template ref to the popover (for attaching it to the anchor), this makes it easier to do.

Partially addresses https://github.com/ncsu-sat/popover/issues/29