### PR TITLE
feat: allow backdrop to be disabled or customized

### DIFF
--- a/demo/app/demo.component.ts
+++ b/demo/app/demo.component.ts
@@ -69,7 +69,7 @@ import { SatPopoverAnchor } from '@sat/popover';
         <sat-popover #fancyPopover
             xPosition="center"
             yPosition="below"
-            backdropClass="demo-background-green">
+            backdropClass="demo-background-rainbow">
           <div style="background: pink; padding: 32px; border-radius: 8px"
               class="mat-elevation-z4">
             Quite fancy indeed 🎩

--- a/demo/app/demo.component.ts
+++ b/demo/app/demo.component.ts
@@ -84,7 +84,7 @@ import { SatPopoverAnchor } from '@sat/popover';
               [satPopoverAnchorFor]="bluePopover">
           </div>
         </mat-card-content>
-        <sat-popover #bluePopover>
+        <sat-popover #bluePopover disableBackdrop>
           <div style="background: lightblue; padding: 16px">BLUE!</div>
         </sat-popover>
         <mat-card-actions>

--- a/demo/app/demo.component.ts
+++ b/demo/app/demo.component.ts
@@ -68,7 +68,8 @@ import { SatPopoverAnchor } from '@sat/popover';
 
         <sat-popover #fancyPopover
             xPosition="center"
-            yPosition="below">
+            yPosition="below"
+            backdropClass="demo-background-green">
           <div style="background: pink; padding: 32px; border-radius: 8px"
               class="mat-elevation-z4">
             Quite fancy indeed 🎩

--- a/demo/styles.scss
+++ b/demo/styles.scss
@@ -14,3 +14,7 @@ html, body {
   height: 100%;
   margin: 0;
 }
+
+.demo-background-green {
+  background: linear-gradient(to right, orange , yellow, green, cyan, blue, violet);
+}

--- a/demo/styles.scss
+++ b/demo/styles.scss
@@ -15,6 +15,6 @@ html, body {
   margin: 0;
 }
 
-.demo-background-green {
+.demo-background-rainbow {
   background: linear-gradient(to right, orange , yellow, green, cyan, blue, violet);
 }

--- a/lib/popover/popover-anchor.directive.ts
+++ b/lib/popover/popover-anchor.directive.ts
@@ -197,7 +197,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   private _getOverlayConfig(): OverlayConfig {
     const config = new OverlayConfig();
     config.positionStrategy = this._getPosition();
-    config.hasBackdrop = true;
+    config.hasBackdrop = !this.attachedPopover.disableBackdrop;
     config.backdropClass = 'cdk-overlay-transparent-backdrop';
     config.scrollStrategy = this._overlay.scrollStrategies.reposition();
 

--- a/lib/popover/popover-anchor.directive.ts
+++ b/lib/popover/popover-anchor.directive.ts
@@ -198,7 +198,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
     const config = new OverlayConfig();
     config.positionStrategy = this._getPosition();
     config.hasBackdrop = !this.attachedPopover.disableBackdrop;
-    config.backdropClass = 'cdk-overlay-transparent-backdrop';
+    config.backdropClass = this.attachedPopover.backdropClass || 'cdk-overlay-transparent-backdrop';
     config.scrollStrategy = this._overlay.scrollStrategies.reposition();
 
     return config;

--- a/lib/popover/popover.component.ts
+++ b/lib/popover/popover.component.ts
@@ -14,6 +14,7 @@ import {
 import { AnimationEvent } from '@angular/animations';
 import { DOCUMENT } from '@angular/platform-browser';
 import { FocusTrap, FocusTrapFactory } from '@angular/cdk/a11y';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { ESCAPE } from '@angular/cdk/keycodes';
 import { Subject } from 'rxjs/Subject';
 
@@ -48,6 +49,13 @@ export class SatPopover implements AfterViewInit {
     this._setPositionClasses();
   }
   private _yPosition: SatPopoverPositionY = 'center';
+
+  @Input()
+  get disableBackdrop() { return this._disableBackdrop; }
+  set disableBackdrop(val: boolean) {
+    this._disableBackdrop = coerceBooleanProperty(val);
+  }
+  private _disableBackdrop = false;
 
   /** Whether the popover should overlap its anchor. */
   @Input() overlapAnchor = true;

--- a/lib/popover/popover.component.ts
+++ b/lib/popover/popover.component.ts
@@ -50,12 +50,16 @@ export class SatPopover implements AfterViewInit {
   }
   private _yPosition: SatPopoverPositionY = 'center';
 
+  /** Whether the backdrop should be disabled (includes closing on click). */
   @Input()
   get disableBackdrop() { return this._disableBackdrop; }
   set disableBackdrop(val: boolean) {
     this._disableBackdrop = coerceBooleanProperty(val);
   }
   private _disableBackdrop = false;
+
+  /** Optional backdrop class. */
+  @Input() backdropClass = '';
 
   /** Whether the popover should overlap its anchor. */
   @Input() overlapAnchor = true;


### PR DESCRIPTION
Partially addresses https://github.com/ncsu-sat/popover/issues/29

By applying the `disableBackdrop` attribute to the `sat-popover`, backdrops will no longer block interaction with the page. This should enable hover support without obstructing mouseleave events.