### PR TITLE
chore: remove default toggle behave and make backdrops opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ export class AppModule { }
 
 ## Usage
 
+### Getting started
+
 Wrap any component you want to display in a popover with an `<sat-popover>` component.
 
 ```html
@@ -60,7 +62,7 @@ Wrap any component you want to display in a popover with an `<sat-popover>` comp
 Next, hook the popover to an anchor element.
 
 ```html
-<button [satPopoverAnchorFor]="contactPopover">
+<button [satPopoverAnchorFor]="contactPopover" (click)="contactPopover.toggle()">
   See Contact Details
 </button>
 
@@ -69,8 +71,10 @@ Next, hook the popover to an anchor element.
 </sat-popover>
 ```
 
-By default, whenever the button is clicked, the `<app-contact-overview>` popover will appear
-centered over the button. If you instead want the popover to appear below the anchor:
+### Positioning
+
+By default, the popover will appear centered over the button. If you instead want the popover
+to appear below the anchor:
 
 ```html
 <sat-popover #contactPopover yPosition="below" [overlapAnchor]="false">
@@ -89,28 +93,57 @@ You can use the following to position the popover around the anchor:
 > Note: When the `xPosition` and `yPosition` are both `'center'`, `overlapAnchor` will have no
 effect.
 
-If you want to respond to events other than anchor clicks, you can disable the click handler
-and implement your own:
+### Opening and closing
+
+You are in full control of when the popover opens and closes. You can hook into any event or
+trigger that fits your application's needs.
+
+The `SatPopover` has the following methods,
+
+* `open`
+* `close`
+* `toggle`
+
+The `SatPopoverAnchor` has similar methods,
+
+* `openPopover`
+* `closePopover`
+* `togglePopover`
+
+### Backdrop
+
+You can add a fullscreen backdrop that appears behind the popover when it is open. It prevents
+interaction with the rest of the application and will automatically close the popover when
+clicked. To add it to your popover, use `showBackdrop`.
 
 ```html
-<button [satPopoverAnchorFor]="contactPopover" satDisableClick>
-  See Details
-</button>
+<sat-popover #myBlockingPopover showBackdrop>
+  <!-- ... -->
+</sat-popover>
 ```
 
-```ts
-@ViewChild(SatPopoverAnchor) anchor: SatPopoverAnchor;
+If used, the default backdrop will be transparent. You can add any custom backdrop class with
+`backdropClass`.
 
-openContactPopover(): void {
-  this.anchor.openPopover();
-}
+```html
+<sat-popover #myBlockingPopover showBackdrop backdropClass="app-fancy-backdrop">
+  <!-- ... -->
+</sat-popover>
 ```
+
+> Note: if you plan on using `mouseenter` and `mouseleave` events to open and close your popover,
+keep in mind that a backdrop will block pointer events once it is open, immediately triggering
+a `mouseleave` event.
 
 ## Styles
 
 The `<sat-popover>` component only provides styles to affect its own transform origin. It is
 the responsibility of the elements you project inside the popover to styles themselves. This
 includes background color, box shadows, margin offsets, etc.
+
+## Examples
+
+StackBlitz examples coming soon.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ Next, hook the popover to an anchor element.
   See Contact Details
 </button>
 
-<sat-popover #contactPopover showBackdrop>
+<sat-popover #contactPopover hasBackdrop>
   <app-contact-overview [contact]="myContact"></app-contact-overview>
 </sat-popover>
 ```
 
-> Note: `showBackdrop` is explained below
+> Note: `hasBackdrop` is explained below
 
 ### Positioning
 
@@ -116,10 +116,10 @@ trigger that fits your application's needs.
 
 You can add a fullscreen backdrop that appears behind the popover when it is open. It prevents
 interaction with the rest of the application and will automatically close the popover when
-clicked. To add it to your popover, use `showBackdrop`.
+clicked. To add it to your popover, use `hasBackdrop`.
 
 ```html
-<sat-popover #myBlockingPopover showBackdrop>
+<sat-popover #myBlockingPopover hasBackdrop>
   <!-- ... -->
 </sat-popover>
 ```
@@ -128,7 +128,7 @@ If used, the default backdrop will be transparent. You can add any custom backdr
 `backdropClass`.
 
 ```html
-<sat-popover #myBlockingPopover showBackdrop backdropClass="app-fancy-backdrop">
+<sat-popover #myBlockingPopover hasBackdrop backdropClass="app-fancy-backdrop">
   <!-- ... -->
 </sat-popover>
 ```

--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ Next, hook the popover to an anchor element.
   See Contact Details
 </button>
 
-<sat-popover #contactPopover>
+<sat-popover #contactPopover showBackdrop>
   <app-contact-overview [contact]="myContact"></app-contact-overview>
 </sat-popover>
 ```
+
+> Note: `showBackdrop` is explained below
 
 ### Positioning
 
@@ -90,7 +92,7 @@ You can use the following to position the popover around the anchor:
 | yPosition     | 'above' \| 'center' \| 'below'  | 'center' |
 | overlapAnchor | boolean                         | true     |
 
-> Note: When the `xPosition` and `yPosition` are both `'center'`, `overlapAnchor` will have no
+> Note: When `xPosition` and `yPosition` are both `'center'`, `overlapAnchor` will have no
 effect.
 
 ### Opening and closing
@@ -98,13 +100,13 @@ effect.
 You are in full control of when the popover opens and closes. You can hook into any event or
 trigger that fits your application's needs.
 
-The `SatPopover` has the following methods,
+`SatPopover` has the following methods,
 
 * `open`
 * `close`
 * `toggle`
 
-The `SatPopoverAnchor` has similar methods,
+`SatPopoverAnchor` has similar methods,
 
 * `openPopover`
 * `closePopover`

--- a/src/demo/app/demo.component.ts
+++ b/src/demo/app/demo.component.ts
@@ -29,8 +29,7 @@ import { SatPopoverAnchor } from '@sat/popover';
           </button>
           <button mat-raised-button
               [satPopoverAnchorFor]="popover3"
-              (mouseenter)="popover3.open()"
-              >
+              (mouseenter)="popover3.open()">
             Woo! ·
           </button>
         </mat-card-content>

--- a/src/demo/app/demo.component.ts
+++ b/src/demo/app/demo.component.ts
@@ -17,14 +17,28 @@ import { SatPopoverAnchor } from '@sat/popover';
       <mat-card>
         <mat-card-title>Click the buttons</mat-card-title>
         <mat-card-content>
-          <button mat-raised-button [satPopoverAnchorFor]="popover1">Woo! ↘</button>
-          <button mat-raised-button [satPopoverAnchorFor]="popover2">Woo! ←</button>
-          <button mat-raised-button [satPopoverAnchorFor]="popover3">Woo! ·</button>
+          <button mat-raised-button
+              [satPopoverAnchorFor]="popover1"
+              (click)="popover1.toggle()">
+            Woo! ↘
+          </button>
+          <button mat-raised-button
+              [satPopoverAnchorFor]="popover2"
+              (click)="popover2.toggle()">
+            Woo! ←
+          </button>
+          <button mat-raised-button
+              [satPopoverAnchorFor]="popover3"
+              (mouseenter)="popover3.open()"
+              >
+            Woo! ·
+          </button>
         </mat-card-content>
 
         <sat-popover #popover1
             xPosition="after"
             yPosition="below"
+            hasBackdrop
             [overlapAnchor]="false">
           <div style="background: lightgray; padding: 48px">
             Oh, cool
@@ -34,6 +48,7 @@ import { SatPopoverAnchor } from '@sat/popover';
         <sat-popover #popover2
             xPosition="before"
             yPosition="center"
+            hasBackdrop
             [overlapAnchor]="false">
           <div style="background: lightgray; padding: 48px" class="mat-elevation-z12">
             Oh, neat
@@ -44,7 +59,11 @@ import { SatPopoverAnchor } from '@sat/popover';
             xPosition="center"
             yPosition="center"
             [overlapAnchor]="false">
-          <mat-toolbar color="accent" class="mat-elevation-z2">Oh, nifty</mat-toolbar>
+          <mat-toolbar color="accent"
+              class="mat-elevation-z2"
+              (mouseleave)="popover3.close()">
+            Oh, nifty
+          </mat-toolbar>
         </sat-popover>
 
       </mat-card>
@@ -69,6 +88,7 @@ import { SatPopoverAnchor } from '@sat/popover';
         <sat-popover #fancyPopover
             xPosition="center"
             yPosition="below"
+            hasBackdrop
             backdropClass="demo-background-rainbow">
           <div style="background: pink; padding: 32px; border-radius: 8px"
               class="mat-elevation-z4">
@@ -85,7 +105,7 @@ import { SatPopoverAnchor } from '@sat/popover';
               [satPopoverAnchorFor]="bluePopover">
           </div>
         </mat-card-content>
-        <sat-popover #bluePopover disableBackdrop>
+        <sat-popover #bluePopover>
           <div style="background: lightblue; padding: 16px">BLUE!</div>
         </sat-popover>
         <mat-card-actions>

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -47,14 +47,6 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   }
   private _attachedPopover: SatPopover;
 
-  /** Whether clicking the target element will automatically toggle the popover. */
-  @Input('satDisablePopoverToggle')
-  get disablePopoverToggle() { return this._disablePopoverToggle; }
-  set disablePopoverToggle(value: boolean) {
-    this._disablePopoverToggle = coerceBooleanProperty(value);
-  }
-  private _disablePopoverToggle = false;
-
   /** Emits when the popover is opened. */
   @Output() popoverOpened = new EventEmitter<void>();
 
@@ -137,14 +129,6 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
     if (this._overlayRef) {
       this._overlayRef.dispose();
       this._overlayRef = null;
-    }
-  }
-
-  /** Toggle the popover when host element is clicked. */
-  @HostListener('click')
-  private _anchorClicked(): void {
-    if (!this._disablePopoverToggle) {
-      this.togglePopover();
     }
   }
 

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -181,7 +181,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   private _getOverlayConfig(): OverlayConfig {
     const config = new OverlayConfig();
     config.positionStrategy = this._getPosition();
-    config.hasBackdrop = !this.attachedPopover.disableBackdrop;
+    config.hasBackdrop = this.attachedPopover.showBackdrop;
     config.backdropClass = this.attachedPopover.backdropClass || 'cdk-overlay-transparent-backdrop';
     config.scrollStrategy = this._overlay.scrollStrategies.reposition();
 

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -2,7 +2,6 @@ import {
   Directive,
   ElementRef,
   EventEmitter,
-  HostListener,
   Input,
   OnInit,
   OnDestroy,
@@ -18,7 +17,6 @@ import {
   VerticalConnectionPos
 } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/takeUntil';

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -179,7 +179,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   private _getOverlayConfig(): OverlayConfig {
     const config = new OverlayConfig();
     config.positionStrategy = this._getPosition();
-    config.hasBackdrop = this.attachedPopover.showBackdrop;
+    config.hasBackdrop = this.attachedPopover.hasBackdrop;
     config.backdropClass = this.attachedPopover.backdropClass || 'cdk-overlay-transparent-backdrop';
     config.scrollStrategy = this._overlay.scrollStrategies.reposition();
 

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -52,11 +52,11 @@ export class SatPopover implements AfterViewInit {
 
   /** Whether the popover should have a backdrop (includes closing on click). */
   @Input()
-  get showBackdrop() { return this._showBackdrop; }
-  set showBackdrop(val: boolean) {
-    this._showBackdrop = coerceBooleanProperty(val);
+  get hasBackdrop() { return this._hasBackdrop; }
+  set hasBackdrop(val: boolean) {
+    this._hasBackdrop = coerceBooleanProperty(val);
   }
-  private _showBackdrop = false;
+  private _hasBackdrop = false;
 
   /** Optional backdrop class. */
   @Input() backdropClass = '';

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -50,13 +50,13 @@ export class SatPopover implements AfterViewInit {
   }
   private _yPosition: SatPopoverPositionY = 'center';
 
-  /** Whether the backdrop should be disabled (includes closing on click). */
+  /** Whether the popover should have a backdrop (includes closing on click). */
   @Input()
-  get disableBackdrop() { return this._disableBackdrop; }
-  set disableBackdrop(val: boolean) {
-    this._disableBackdrop = coerceBooleanProperty(val);
+  get showBackdrop() { return this._showBackdrop; }
+  set showBackdrop(val: boolean) {
+    this._showBackdrop = coerceBooleanProperty(val);
   }
-  private _disableBackdrop = false;
+  private _showBackdrop = false;
 
   /** Optional backdrop class. */
   @Input() backdropClass = '';


### PR DESCRIPTION
- It is now up to the consumer to manage opening/closing/toggling behavior
  - Due to `(click)="myPopover.toggle()"` and `satDisablePopoverToggle` being approx. equally verbose, and neither behavior necessarily taking precedence, it seems best to make it opt in
- It is now up to the consumer to specify when to show a backdrop
  - Basically the same reasoning as the disable toggle. The goal is to make easily opt-in solutions that are flexible for a variety of needs, rather than prescribing a solution that req's several "disable apis" to support other use cases