### PR TITLE
fix: close popover when escape key is pressed

### DIFF
--- a/src/demo/app/demo.component.ts
+++ b/src/demo/app/demo.component.ts
@@ -113,6 +113,23 @@ import { SatPopoverAnchor } from '@sat/popover';
           <button mat-button (click)="bluePopover.toggle()">Toggle</button>
         </mat-card-actions>
       </mat-card>
+
+      <!-- FOCUS -->
+      <mat-card>
+        <mat-card-title>Focus Behavior</mat-card-title>
+        <mat-card-content>
+          <button mat-mini-fab [satPopoverAnchorFor]="editPopover" (click)="editPopover.open()">
+            <mat-icon>create</mat-icon>
+          </button>
+        </mat-card-content>
+        <sat-popover #editPopover hasBackdrop>
+          <div style="background: white; padding: 16px; border: solid 1px black">
+            <input type="text" placeholder="Input 1"> <br>
+            <input type="text" placeholder="Input 2">
+          </div>
+        </sat-popover>
+      </mat-card>
+
     </div>
   `
 })

--- a/src/demo/app/demo.module.ts
+++ b/src/demo/app/demo.module.ts
@@ -7,6 +7,7 @@ import {
   MatCardModule,
   MatButtonModule,
   MatSelectModule,
+  MatIconModule,
 } from '@angular/material';
 
 import { DemoComponent } from './demo.component';
@@ -17,6 +18,7 @@ import { DemoComponent } from './demo.component';
     MatCardModule,
     MatButtonModule,
     MatSelectModule,
+    MatIconModule,
   ]
 })
 export class DemoMaterialModule { }

--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -7,6 +7,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
   <sat-demo></sat-demo>

--- a/src/lib/popover/notification.service.ts
+++ b/src/lib/popover/notification.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+
+/** Enumerated actions for a popover to perform. */
+export enum NotificationAction {
+  OPEN,
+  CLOSE,
+  TOGGLE,
+}
+
+/** Event object for dispatching to anchor. */
+export class PopoverNotification {
+  constructor(
+    /** Action to perform. */
+    public action: NotificationAction,
+    /** Optional payload. */
+    public value?: any
+  ) { }
+}
+
+@Injectable()
+export class PopoverNotificationService {
+
+  private store = new Subject<PopoverNotification>();
+
+  /** Dispatch a notification to all subscribers. */
+  dispatch(notification: PopoverNotification) {
+    this.store.next(notification);
+  }
+
+  /** Stream of notification events. */
+  events(): Observable<PopoverNotification> {
+    return this.store.asObservable();
+  }
+
+}

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -41,7 +41,10 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   @Input('satPopoverAnchorFor')
   get attachedPopover() { return this._attachedPopover; }
   set attachedPopover(value: SatPopover) {
+    // ensure that value is a popover
     this._validateAttachedPopover(value);
+    // store value and provide notification service as a communication
+    // channel between popover and anchor
     this._attachedPopover = value;
     this._attachedPopover._notifications = this._notifications;
   }
@@ -127,19 +130,23 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   }
 
   /**
-   * Whenever a new popover is attached to this anchor, observe
-   * its action subject to dispatch the appropriate action.
+   * Call appropriate anchor method when an event is dispatched through
+   * the notification service.
    */
   private _subscribeToNotifications(): void {
     this._notifications.events()
       .takeUntil(this._onDestroy)
       .subscribe(event => {
-        if (event.action === NotificationAction.OPEN) {
-          this.openPopover();
-        } else if (event.action === NotificationAction.CLOSE) {
-          this.closePopover(event.value);
-        } else if (event.action === NotificationAction.TOGGLE) {
-          this.togglePopover();
+        switch (event.action) {
+          case NotificationAction.OPEN:
+            this.openPopover();
+            break;
+          case NotificationAction.CLOSE:
+            this.closePopover(event.value);
+            break;
+          case NotificationAction.TOGGLE:
+            this.togglePopover();
+            break;
         }
       });
   }
@@ -162,7 +169,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
   }
 
   /** Save the closed state of the popover and emit. */
-  private _saveClosedState(value): void {
+  private _saveClosedState(value?: any): void {
     this.attachedPopover._open = this._popoverOpen = false;
 
     this.popoverClosed.emit(value);

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -132,7 +132,6 @@ export class SatPopover implements AfterViewInit {
 
   /** Respond to key events. */
   _handleKeydown(event: KeyboardEvent): void {
-    console.log('!', event);
     if (event.keyCode === ESCAPE) {
       event.stopPropagation();
       this.close();

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -132,6 +132,7 @@ export class SatPopover implements AfterViewInit {
 
   /** Respond to key events. */
   _handleKeydown(event: KeyboardEvent): void {
+    console.log('!', event);
     if (event.keyCode === ESCAPE) {
       event.stopPropagation();
       this.close();

--- a/src/lib/popover/popover.errors.ts
+++ b/src/lib/popover/popover.errors.ts
@@ -1,3 +1,7 @@
 export function getInvalidPopoverError(): Error {
   return Error('SatPopoverAnchor must be provided an SatPopover component instance.');
 }
+
+export function getUnanchoredPopoverError(): Error {
+  return Error('SatPopover is not anchored to any SatPopoverAnchor');
+}

--- a/src/lib/popover/popover.errors.ts
+++ b/src/lib/popover/popover.errors.ts
@@ -3,5 +3,5 @@ export function getInvalidPopoverError(): Error {
 }
 
 export function getUnanchoredPopoverError(): Error {
-  return Error('SatPopover is not anchored to any SatPopoverAnchor');
+  return Error('SatPopover is not anchored to any SatPopoverAnchor.');
 }

--- a/src/lib/popover/popover.spec.ts
+++ b/src/lib/popover/popover.spec.ts
@@ -84,64 +84,64 @@ describe('SatPopover', () => {
 
     it('should open with open()', () => {
       fixture.detectChanges();
-      expect(overlayContainerElement.textContent).toBe('');
+      expect(overlayContainerElement.textContent).toBe('', 'Initially closed');
       comp.popover.open();
-      expect(overlayContainerElement.textContent).toContain('Popover');
+      expect(overlayContainerElement.textContent).toContain('Popover', 'Subsequently open');
     });
 
     it('should open with openPopover()', () => {
       fixture.detectChanges();
-      expect(overlayContainerElement.textContent).toBe('');
+      expect(overlayContainerElement.textContent).toBe('', 'Initially closed');
       comp.anchor.openPopover();
-      expect(overlayContainerElement.textContent).toContain('Popover');
+      expect(overlayContainerElement.textContent).toContain('Popover', 'Subsequently open');
     });
 
     it('should close with close()', fakeAsync(() => {
       fixture.detectChanges();
       comp.popover.open();
-      expect(overlayContainerElement.textContent).toContain('Popover');
+      expect(overlayContainerElement.textContent).toContain('Popover', 'Initially open');
 
       comp.popover.close();
       fixture.detectChanges();
       tick();
-      expect(overlayContainerElement.textContent).toBe('');
+      expect(overlayContainerElement.textContent).toBe('', 'Subsequently closed');
     }));
 
     it('should close with closePopover()', fakeAsync(() => {
       fixture.detectChanges();
       comp.anchor.openPopover();
-      expect(overlayContainerElement.textContent).toContain('Popover');
+      expect(overlayContainerElement.textContent).toContain('Popover', 'Initially open');
 
       comp.anchor.closePopover();
       fixture.detectChanges();
       tick();
-      expect(overlayContainerElement.textContent).toBe('');
+      expect(overlayContainerElement.textContent).toBe('', 'Subsequently closed');
     }));
 
     it('should toggle with toggle()', fakeAsync(() => {
       fixture.detectChanges();
-      expect(overlayContainerElement.textContent).toBe('');
+      expect(overlayContainerElement.textContent).toBe('', 'Initially closed');
 
       comp.popover.toggle();
-      expect(overlayContainerElement.textContent).toContain('Popover');
+      expect(overlayContainerElement.textContent).toContain('Popover', 'Subsequently open');
 
       comp.popover.toggle();
       fixture.detectChanges();
       tick();
-      expect(overlayContainerElement.textContent).toBe('');
+      expect(overlayContainerElement.textContent).toBe('', 'Closed after second toggle');
     }));
 
     it('should toggle with togglePopover()', fakeAsync(() => {
       fixture.detectChanges();
-      expect(overlayContainerElement.textContent).toBe('');
+      expect(overlayContainerElement.textContent).toBe('', 'Initially closed');
 
       comp.anchor.togglePopover();
-      expect(overlayContainerElement.textContent).toContain('Popover');
+      expect(overlayContainerElement.textContent).toContain('Popover', 'Subsequently open');
 
       comp.anchor.togglePopover();
       fixture.detectChanges();
       tick();
-      expect(overlayContainerElement.textContent).toBe('');
+      expect(overlayContainerElement.textContent).toBe('', 'Closed after second toggle');
     }));
 
     it('should emit when opened', () => {
@@ -154,8 +154,8 @@ describe('SatPopover', () => {
 
       comp.popover.open();
 
-      expect(popoverOpenedEvent).toBe(true);
-      expect(anchorOpenedEvent).toBe(true);
+      expect(popoverOpenedEvent).toBe(true, 'popoverOpened called');
+      expect(anchorOpenedEvent).toBe(true, 'anchorOpened called');
     });
 
     it('should emit when closed', fakeAsync(() => {
@@ -172,8 +172,8 @@ describe('SatPopover', () => {
       fixture.detectChanges();
       tick();
 
-      expect(popoverClosedEvent).toBe(true);
-      expect(anchorClosedEvent).toBe(true);
+      expect(popoverClosedEvent).toBe(true, 'popoverClosed called');
+      expect(anchorClosedEvent).toBe(true, 'anchorClosed called');
     }));
 
     it('should emit a value when closed with a value', fakeAsync(() => {
@@ -194,8 +194,8 @@ describe('SatPopover', () => {
       tick();
 
       // Working when closed via anchor api
-      expect(popoverClosedValue).toBe(firstTestVal);
-      expect(anchorClosedValue).toBe(firstTestVal);
+      expect(popoverClosedValue).toBe(firstTestVal, 'popoverClosed with value - anchor api');
+      expect(anchorClosedValue).toBe(firstTestVal, 'anchorClosed with value - anchor api');
 
       comp.popover.open();
       fixture.detectChanges();
@@ -205,27 +205,27 @@ describe('SatPopover', () => {
       tick();
 
       // Working when closed via popover api
-      expect(popoverClosedValue).toBe(secondTestVal);
-      expect(anchorClosedValue).toBe(secondTestVal);
+      expect(popoverClosedValue).toBe(secondTestVal, 'popoverClosed with value - popover api');
+      expect(anchorClosedValue).toBe(secondTestVal, 'anchorClosed with value - popover api');
     }));
 
     it('should return whether the popover is presently open', fakeAsync(() => {
       fixture.detectChanges();
 
-      expect(comp.anchor.isPopoverOpen()).toBe(false);
-      expect(comp.popover.isOpen()).toBe(false);
+      expect(comp.anchor.isPopoverOpen()).toBe(false, 'Initially closed - anchor');
+      expect(comp.popover.isOpen()).toBe(false, 'Initially closed - popover');
 
       comp.popover.open();
 
-      expect(comp.anchor.isPopoverOpen()).toBe(true);
-      expect(comp.popover.isOpen()).toBe(true);
+      expect(comp.anchor.isPopoverOpen()).toBe(true, 'Subsequently opened - anchor');
+      expect(comp.popover.isOpen()).toBe(true, 'Subsequently opened - popover');
 
       comp.popover.close();
       fixture.detectChanges();
       tick();
 
-      expect(comp.anchor.isPopoverOpen()).toBe(false);
-      expect(comp.popover.isOpen()).toBe(false);
+      expect(comp.anchor.isPopoverOpen()).toBe(false, 'Finally closed - anchor');
+      expect(comp.popover.isOpen()).toBe(false, 'Finally closed - popover');
     }));
 
   });
@@ -332,25 +332,20 @@ describe('SatPopover', () => {
       fixture.detectChanges();
       comp.popover.open();
 
-      expect(overlayContainerElement.textContent).toContain('Popover');
+      // Let focus move to the first focusable element
+      fixture.detectChanges();
+      tick();
 
-      // TODO dispatch escape event on the popover
-      // const event = new KeyboardEvent('keydown', { 'code': 'ESCAPE' });
+      expect(overlayContainerElement.textContent).toContain('Popover', 'Initially open');
 
-      const container = overlayContainerElement.querySelector('.sat-popover-container');
-      console.log(container);
-
+      // Emit ESCAPE keydown event
       const currentlyFocusedElement = document.activeElement;
       currentlyFocusedElement.dispatchEvent(createKeyboardEvent('keydown', ESCAPE));
-
-      // comp.popover._handleKeydown(e);
-
-      // fixture.nativeElement.dispatchEvent(event);
 
       fixture.detectChanges();
       tick(500);
 
-      expect(overlayContainerElement.textContent).toBe('');
+      expect(overlayContainerElement.textContent).toBe('', 'Closed after escape keydown');
     }));
 
   });
@@ -435,10 +430,7 @@ export class KeyboardPopoverTestComponent {
 }
 
 
-/**
- * This factory function provides an overlay container under test
- * control.
- */
+/** This factory function provides an overlay container under test control. */
 const overlayContainerFactory = () => {
   const element = document.createElement('div');
   element.classList.add('cdk-overlay-container');
@@ -452,8 +444,7 @@ const overlayContainerFactory = () => {
 };
 
 
-
-/** Dispatches a keydown event from an element. */
+/** Dispatches a keydown event from an element. From angular/material2 */
 export function createKeyboardEvent(type: string, keyCode: number, target?: Element, key?: string) {
   const event = document.createEvent('KeyboardEvent') as any;
   // Firefox does not support `initKeyboardEvent`, but supports `initKeyEvent`.


### PR DESCRIPTION
- This was a regression in beta.0
- This also refactors how the popover communicates to the anchor by adding a middleman dispatcher service.
- This adds a warning when open/close/toggle methods are called on a popover with no corresponding anchor
- This adds escape/focus demo to the demo app