### PR TITLE
fix: recreate overlay when target positions are changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3761,14 +3761,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3777,6 +3769,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -8474,15 +8474,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8492,6 +8483,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/demo/app/demo.component.scss
+++ b/src/demo/app/demo.component.scss
@@ -5,8 +5,8 @@
 
 .page-content {
   padding: 48px;
-}
 
-.mat-card {
-  margin-bottom: 32px;
+  & > * {
+    margin-bottom: 32px;
+  }
 }

--- a/src/demo/app/demo.component.scss
+++ b/src/demo/app/demo.component.scss
@@ -7,6 +7,7 @@
   padding: 48px;
 
   & > * {
+    // separate each example
     margin-bottom: 32px;
   }
 }

--- a/src/demo/app/demo.component.ts
+++ b/src/demo/app/demo.component.ts
@@ -13,59 +13,7 @@ import { SatPopoverAnchor } from '@sat/popover';
 
     <div class="page-content">
 
-      <!-- BUTTONS -->
-      <mat-card>
-        <mat-card-title>Click the buttons</mat-card-title>
-        <mat-card-content>
-          <button mat-raised-button
-              [satPopoverAnchorFor]="popover1"
-              (click)="popover1.toggle()">
-            Woo! ↘
-          </button>
-          <button mat-raised-button
-              [satPopoverAnchorFor]="popover2"
-              (click)="popover2.toggle()">
-            Woo! ←
-          </button>
-          <button mat-raised-button
-              [satPopoverAnchorFor]="popover3"
-              (mouseenter)="popover3.open()">
-            Woo! ·
-          </button>
-        </mat-card-content>
-
-        <sat-popover #popover1
-            xPosition="after"
-            yPosition="below"
-            hasBackdrop
-            [overlapAnchor]="false">
-          <div style="background: lightgray; padding: 48px">
-            Oh, cool
-          </div>
-        </sat-popover>
-
-        <sat-popover #popover2
-            xPosition="before"
-            yPosition="center"
-            hasBackdrop
-            [overlapAnchor]="false">
-          <div style="background: lightgray; padding: 48px" class="mat-elevation-z12">
-            Oh, neat
-          </div>
-        </sat-popover>
-
-        <sat-popover #popover3
-            xPosition="center"
-            yPosition="center"
-            [overlapAnchor]="false">
-          <mat-toolbar color="accent"
-              class="mat-elevation-z2"
-              (mouseleave)="popover3.close()">
-            Oh, nifty
-          </mat-toolbar>
-        </sat-popover>
-
-      </mat-card>
+      <demo-positioning></demo-positioning>
 
       <!-- SELECT OPTION -->
       <mat-card>

--- a/src/demo/app/demo.module.ts
+++ b/src/demo/app/demo.module.ts
@@ -1,5 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SatPopoverModule } from '@sat/popover';
 import {
@@ -8,9 +9,11 @@ import {
   MatButtonModule,
   MatSelectModule,
   MatIconModule,
+  MatCheckboxModule,
 } from '@angular/material';
 
 import { DemoComponent } from './demo.component';
+import { PositioningDemo } from './positioning/positioning.component';
 
 @NgModule({
   exports: [
@@ -19,19 +22,22 @@ import { DemoComponent } from './demo.component';
     MatButtonModule,
     MatSelectModule,
     MatIconModule,
+    MatCheckboxModule,
   ]
 })
 export class DemoMaterialModule { }
 
 @NgModule({
   declarations: [
-    DemoComponent
+    DemoComponent,
+    PositioningDemo,
   ],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
     DemoMaterialModule,
     SatPopoverModule,
+    FormsModule,
   ],
   providers: [],
   bootstrap: [DemoComponent]

--- a/src/demo/app/demo.module.ts
+++ b/src/demo/app/demo.module.ts
@@ -8,6 +8,7 @@ import {
   MatCardModule,
   MatButtonModule,
   MatSelectModule,
+  MatInputModule,
   MatIconModule,
   MatCheckboxModule,
 } from '@angular/material';
@@ -21,6 +22,7 @@ import { PositioningDemo } from './positioning/positioning.component';
     MatCardModule,
     MatButtonModule,
     MatSelectModule,
+    MatInputModule,
     MatIconModule,
     MatCheckboxModule,
   ]

--- a/src/demo/app/positioning/positioning.component.scss
+++ b/src/demo/app/positioning/positioning.component.scss
@@ -1,0 +1,12 @@
+:host {
+  display: block;
+}
+
+.config {
+  margin-bottom: 16px;
+}
+
+.popover {
+  background: lightgray;
+  padding: 48px;
+}

--- a/src/demo/app/positioning/positioning.component.ts
+++ b/src/demo/app/positioning/positioning.component.ts
@@ -14,6 +14,7 @@ import { Component } from '@angular/core';
               <mat-option value="before">Before</mat-option>
               <mat-option value="center">Center</mat-option>
               <mat-option value="after">After</mat-option>
+              <mat-option value="octopus">Octopus</mat-option>
             </mat-select>
           </mat-form-field>
 
@@ -22,6 +23,7 @@ import { Component } from '@angular/core';
               <mat-option value="above">Above</mat-option>
               <mat-option value="center">Center</mat-option>
               <mat-option value="below">Below</mat-option>
+              <mat-option value="aardvark">Aardvark</mat-option>
             </mat-select>
           </mat-form-field>
 
@@ -53,7 +55,6 @@ import { Component } from '@angular/core';
           Nifty
         </div>
       </sat-popover>
-
 
     </mat-card>
   `

--- a/src/demo/app/positioning/positioning.component.ts
+++ b/src/demo/app/positioning/positioning.component.ts
@@ -25,10 +25,20 @@ import { Component } from '@angular/core';
             </mat-select>
           </mat-form-field>
 
+          <mat-form-field>
+            <input matInput type="number"
+              [(ngModel)]="margin"
+              placeholder="anchor's margin-left (px)">
+          </mat-form-field>
+
           <mat-checkbox [(ngModel)]="overlap">Overlap Trigger</mat-checkbox>
         </div>
 
-        <button mat-raised-button [satPopoverAnchorFor]="p" (click)="p.toggle()">
+        <button mat-raised-button
+            color="accent"
+            [style.marginLeft]="margin + 'px'"
+            [satPopoverAnchorFor]="p"
+            (click)="p.toggle()">
           CLICK TO TOGGLE
         </button>
 
@@ -53,5 +63,6 @@ export class PositioningDemo {
   xPos = 'after';
   yPos = 'center';
   overlap = false;
+  margin = 0;
 
 }

--- a/src/demo/app/positioning/positioning.component.ts
+++ b/src/demo/app/positioning/positioning.component.ts
@@ -1,0 +1,57 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'demo-positioning',
+  styleUrls: ['./positioning.component.scss'],
+  template: `
+    <mat-card>
+      <mat-card-title>Positioning</mat-card-title>
+      <mat-card-content>
+
+        <div class="config">
+          <mat-form-field>
+            <mat-select [(ngModel)]="xPos" placeholder="xPosition">
+              <mat-option value="before">Before</mat-option>
+              <mat-option value="center">Center</mat-option>
+              <mat-option value="after">After</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field>
+            <mat-select [(ngModel)]="yPos" placeholder="yPosition">
+              <mat-option value="above">Above</mat-option>
+              <mat-option value="center">Center</mat-option>
+              <mat-option value="below">Below</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-checkbox [(ngModel)]="overlap">Overlap Trigger</mat-checkbox>
+        </div>
+
+        <button mat-raised-button [satPopoverAnchorFor]="p" (click)="p.toggle()">
+          CLICK TO TOGGLE
+        </button>
+
+      </mat-card-content>
+
+      <sat-popover #p
+          [xPosition]="xPos"
+          [yPosition]="yPos"
+          hasBackdrop
+          [overlapAnchor]="overlap">
+        <div class="popover">
+          Nifty
+        </div>
+      </sat-popover>
+
+
+    </mat-card>
+  `
+})
+export class PositioningDemo {
+
+  xPos = 'after';
+  yPos = 'center';
+  overlap = false;
+
+}

--- a/src/lib/popover/notification.service.ts
+++ b/src/lib/popover/notification.service.ts
@@ -6,7 +6,7 @@ import { Subject } from 'rxjs/Subject';
 export enum NotificationAction {
   /** Popover should open. */
   OPEN,
-  /** Popover should closed. */
+  /** Popover should close. */
   CLOSE,
   /** Popover should toggle open or closed. */
   TOGGLE,

--- a/src/lib/popover/notification.service.ts
+++ b/src/lib/popover/notification.service.ts
@@ -7,6 +7,7 @@ export enum NotificationAction {
   OPEN,
   CLOSE,
   TOGGLE,
+  REPOSITION,
 }
 
 /** Event object for dispatching to anchor. */

--- a/src/lib/popover/notification.service.ts
+++ b/src/lib/popover/notification.service.ts
@@ -4,9 +4,13 @@ import { Subject } from 'rxjs/Subject';
 
 /** Enumerated actions for a popover to perform. */
 export enum NotificationAction {
+  /** Popover should open. */
   OPEN,
+  /** Popover should closed. */
   CLOSE,
+  /** Popover should toggle open or closed. */
   TOGGLE,
+  /** Popover has new target positions. */
   REPOSITION,
 }
 

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -219,6 +219,8 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
     const xPos = this.attachedPopover.xPosition;
     const yPos = this.attachedPopover.yPosition;
 
+    console.log('_getPositiong', xPos, yPos);
+
     // Convert position to value usable by strategy. Invert for the overlay so that 'above' means
     // the overlay is attached at the 'bottom'
     const overlayX = convertToHorizontalPos(xPos, true);

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -61,14 +61,14 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
     return this._popoverOpen;
   }
 
+  /** Reference to the overlay containing the popover component. */
+  _overlayRef: OverlayRef;
+
   /** Whether the popover is presently open. */
   private _popoverOpen = false;
 
   /** Reference to a template portal where the overlay will be attached. */
   private _portal: TemplatePortal<any>;
-
-  /** Reference to the overlay containing the popover component. */
-  private _overlayRef: OverlayRef;
 
   /** Emits when the directive is destroyed. */
   private _onDestroy = new Subject<void>();
@@ -147,6 +147,10 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
           case NotificationAction.TOGGLE:
             this.togglePopover();
             break;
+          case NotificationAction.REPOSITION:
+            // TODO: When the overlay's position can be dynamically changed, do not destroy
+            this.destroyPopover();
+            break;
         }
       });
   }
@@ -218,8 +222,6 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
 
     const xPos = this.attachedPopover.xPosition;
     const yPos = this.attachedPopover.yPosition;
-
-    console.log('_getPositiong', xPos, yPos);
 
     // Convert position to value usable by strategy. Invert for the overlay so that 'above' means
     // the overlay is attached at the 'bottom'

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -46,6 +46,7 @@ export class SatPopover implements AfterViewInit {
   @Input()
   get xPosition() { return this._xPosition; }
   set xPosition(val: SatPopoverPositionX) {
+    console.log('new xpos', val);
     this._xPosition = val;
     this._setPositionClasses();
   }
@@ -55,6 +56,7 @@ export class SatPopover implements AfterViewInit {
   @Input()
   get yPosition() { return this._yPosition; }
   set yPosition(val: SatPopoverPositionY) {
+    console.log('new ypos', val);
     this._yPosition = val;
     this._setPositionClasses();
   }
@@ -167,6 +169,7 @@ export class SatPopover implements AfterViewInit {
 
   /** Apply positioning classes based on positioning inputs. */
   _setPositionClasses(posX = this.xPosition, posY = this.yPosition) {
+    console.log('updating classes');
     this._classList['sat-popover-before'] = posX === 'before';
     this._classList['sat-popover-after']  = posX === 'after';
 
@@ -174,6 +177,8 @@ export class SatPopover implements AfterViewInit {
     this._classList['sat-popover-below'] = posY === 'below';
 
     this._classList['sat-popover-center'] = posX === 'center' || posY === 'center';
+
+    console.log(this._classList);
   }
 
   /** Move the focus inside the focus trap and remember where to return later. */

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -24,10 +24,17 @@ import {
   PopoverNotification,
   PopoverNotificationService,
 } from './notification.service';
-import { getUnanchoredPopoverError } from './popover.errors';
+import {
+  getUnanchoredPopoverError,
+  getInvalidXPositionError,
+  getInvalidYPositionError
+} from './popover.errors';
 
 export type SatPopoverPositionX = 'before' | 'center' | 'after';
 export type SatPopoverPositionY = 'above'  | 'center' | 'below';
+
+const VALID_POSX: SatPopoverPositionX[] = ['before', 'center', 'after'];
+const VALID_POSY: SatPopoverPositionY[] = ['above', 'center', 'below'];
 
 // See http://cubic-bezier.com/#.25,.8,.25,1 for reference.
 const OPEN_TRANSITION  = '200ms cubic-bezier(0.25, 0.8, 0.25, 1)';
@@ -46,6 +53,7 @@ export class SatPopover implements AfterViewInit {
   @Input()
   get xPosition() { return this._xPosition; }
   set xPosition(val: SatPopoverPositionX) {
+    this._validateXPosition(val);
     if (this._xPosition !== val) {
       this._xPosition = val;
       this._setPositionClasses();
@@ -58,6 +66,7 @@ export class SatPopover implements AfterViewInit {
   @Input()
   get yPosition() { return this._yPosition; }
   set yPosition(val: SatPopoverPositionY) {
+    this._validateYPosition(val);
     if (this._yPosition !== val) {
       this._yPosition = val;
       this._setPositionClasses();
@@ -238,5 +247,19 @@ export class SatPopover implements AfterViewInit {
     }
 
     this._notifications.dispatch(notification);
+  }
+
+  /** Throws an error if the position is not a valid xPosition. */
+  private _validateXPosition(pos: SatPopoverPositionX): void {
+    if (VALID_POSX.indexOf(pos) === -1) {
+      throw getInvalidXPositionError(pos);
+    }
+  }
+
+  /** Throws an error if the position is not a valid yPosition. */
+  private _validateYPosition(pos: SatPopoverPositionY): void {
+    if (VALID_POSY.indexOf(pos) === -1) {
+      throw getInvalidYPositionError(pos);
+    }
   }
 }

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -33,8 +33,8 @@ import {
 export type SatPopoverPositionX = 'before' | 'center' | 'after';
 export type SatPopoverPositionY = 'above'  | 'center' | 'below';
 
-const VALID_POSX: SatPopoverPositionX[] = ['before', 'center', 'after'];
-const VALID_POSY: SatPopoverPositionY[] = ['above', 'center', 'below'];
+export const VALID_POSX: SatPopoverPositionX[] = ['before', 'center', 'after'];
+export const VALID_POSY: SatPopoverPositionY[] = ['above', 'center', 'below'];
 
 // See http://cubic-bezier.com/#.25,.8,.25,1 for reference.
 const OPEN_TRANSITION  = '200ms cubic-bezier(0.25, 0.8, 0.25, 1)';

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -46,9 +46,11 @@ export class SatPopover implements AfterViewInit {
   @Input()
   get xPosition() { return this._xPosition; }
   set xPosition(val: SatPopoverPositionX) {
-    console.log('new xpos', val);
-    this._xPosition = val;
-    this._setPositionClasses();
+    if (this._xPosition !== val) {
+      this._xPosition = val;
+      this._setPositionClasses();
+      this._dispatchNotification(new PopoverNotification(NotificationAction.REPOSITION));
+    }
   }
   private _xPosition: SatPopoverPositionX = 'center';
 
@@ -56,11 +58,25 @@ export class SatPopover implements AfterViewInit {
   @Input()
   get yPosition() { return this._yPosition; }
   set yPosition(val: SatPopoverPositionY) {
-    console.log('new ypos', val);
-    this._yPosition = val;
-    this._setPositionClasses();
+    if (this._yPosition !== val) {
+      this._yPosition = val;
+      this._setPositionClasses();
+      this._dispatchNotification(new PopoverNotification(NotificationAction.REPOSITION));
+    }
   }
   private _yPosition: SatPopoverPositionY = 'center';
+
+  /** Whether the popover should overlap its anchor. */
+  @Input()
+  get overlapAnchor() { return this._overlapAnchor; }
+  set overlapAnchor(val: boolean) {
+    const coerced = coerceBooleanProperty(val);
+    if (this._overlapAnchor !== coerced) {
+      this._overlapAnchor = coerced;
+      this._dispatchNotification(new PopoverNotification(NotificationAction.REPOSITION));
+    }
+  }
+  private _overlapAnchor = true;
 
   /** Whether the popover should have a backdrop (includes closing on click). */
   @Input()
@@ -78,9 +94,6 @@ export class SatPopover implements AfterViewInit {
 
   /** Optional backdrop class. */
   @Input() backdropClass = '';
-
-  /** Whether the popover should overlap its anchor. */
-  @Input() overlapAnchor = true;
 
   /** Emits when the popover is opened. */
   @Output() opened = new EventEmitter<void>();
@@ -169,7 +182,6 @@ export class SatPopover implements AfterViewInit {
 
   /** Apply positioning classes based on positioning inputs. */
   _setPositionClasses(posX = this.xPosition, posY = this.yPosition) {
-    console.log('updating classes');
     this._classList['sat-popover-before'] = posX === 'before';
     this._classList['sat-popover-after']  = posX === 'after';
 
@@ -177,8 +189,6 @@ export class SatPopover implements AfterViewInit {
     this._classList['sat-popover-below'] = posY === 'below';
 
     this._classList['sat-popover-center'] = posX === 'center' || posY === 'center';
-
-    console.log(this._classList);
   }
 
   /** Move the focus inside the focus trap and remember where to return later. */

--- a/src/lib/popover/popover.errors.ts
+++ b/src/lib/popover/popover.errors.ts
@@ -5,3 +5,13 @@ export function getInvalidPopoverError(): Error {
 export function getUnanchoredPopoverError(): Error {
   return Error('SatPopover is not anchored to any SatPopoverAnchor.');
 }
+
+export function getInvalidXPositionError(pos): Error {
+  return Error('Invalid xPosition: ' + pos +
+      '. Valid options are \'before\', \'center\', \'after\'');
+}
+
+export function getInvalidYPositionError(pos): Error {
+  return Error('Invalid yPosition: ' + pos +
+      '. Valid options are \'above\', \'center\', \'below\'');
+}

--- a/src/lib/popover/popover.errors.ts
+++ b/src/lib/popover/popover.errors.ts
@@ -1,3 +1,5 @@
+import { VALID_POSX, VALID_POSY } from './popover.component';
+
 export function getInvalidPopoverError(): Error {
   return Error('SatPopoverAnchor must be provided an SatPopover component instance.');
 }
@@ -7,11 +9,13 @@ export function getUnanchoredPopoverError(): Error {
 }
 
 export function getInvalidXPositionError(pos): Error {
-  return Error('Invalid xPosition: ' + pos +
-      '. Valid options are \'before\', \'center\', \'after\'');
+  const errorString = `Invalid xPosition: '${pos}'. Valid options are ` +
+    `${VALID_POSX.map(x => `'${x}'`).join(', ')}.`;
+  return Error(errorString);
 }
 
 export function getInvalidYPositionError(pos): Error {
-  return Error('Invalid yPosition: ' + pos +
-      '. Valid options are \'above\', \'center\', \'below\'');
+  const errorString = `Invalid yPosition: '${pos}'. Valid options are ` +
+  `${VALID_POSY.map(x => `'${x}'`).join(', ')}.`;
+  return Error(errorString);
 }

--- a/src/lib/popover/popover.spec.ts
+++ b/src/lib/popover/popover.spec.ts
@@ -383,6 +383,27 @@ describe('SatPopover', () => {
       document.body.removeChild(overlayContainerElement);
     });
 
+    it('should keep the same overlay when positions are static', fakeAsync(() => {
+      fixture.detectChanges();
+
+      // open the overlay and store the overlayRef
+      comp.popover.open();
+      const overlayAfterFirstOpen = comp.anchor._overlayRef;
+
+      comp.popover.close();
+      fixture.detectChanges();
+      tick();
+
+      // change the position to the same thing and reopen, saving the new overlayRef
+      comp.xPos = 'center';
+      fixture.detectChanges();
+
+      comp.popover.open();
+      const overlayAfterSecondOpen = comp.anchor._overlayRef;
+
+      expect(overlayAfterFirstOpen === overlayAfterSecondOpen).toBe(true);
+    }));
+
     it('should reconstruct the overlay when positions are updated', fakeAsync(() => {
       fixture.detectChanges();
 

--- a/src/lib/popover/popover.spec.ts
+++ b/src/lib/popover/popover.spec.ts
@@ -7,7 +7,12 @@ import { ESCAPE } from '@angular/cdk/keycodes';
 import { SatPopoverModule } from './popover.module';
 import { SatPopover } from './popover.component';
 import { SatPopoverAnchor } from './popover-anchor.directive';
-import { getInvalidPopoverError, getUnanchoredPopoverError } from './popover.errors';
+import {
+  getInvalidPopoverError,
+  getUnanchoredPopoverError,
+  getInvalidXPositionError,
+  getInvalidYPositionError
+} from './popover.errors';
 
 
 describe('SatPopover', () => {
@@ -398,6 +403,28 @@ describe('SatPopover', () => {
 
       expect(overlayAfterFirstOpen === overlayAfterSecondOpen).toBe(false);
     }));
+
+    it('should throw an error when an invalid xPosition is provided', () => {
+      fixture.detectChanges();
+
+      // set invalid xPosition
+      comp.xPos = 'kiwi';
+
+      expect(() => {
+        fixture.detectChanges();
+      }).toThrow(getInvalidXPositionError('kiwi'));
+    });
+
+    it('should throw an error when an invalid yPosition is provided', () => {
+      fixture.detectChanges();
+
+      // set invalid yPosition
+      comp.yPos = 'banana';
+
+      expect(() => {
+        fixture.detectChanges();
+      }).toThrow(getInvalidYPositionError('banana'));
+    });
 
   });
 

--- a/src/lib/popover/popover.spec.ts
+++ b/src/lib/popover/popover.spec.ts
@@ -350,6 +350,57 @@ describe('SatPopover', () => {
 
   });
 
+  describe('positioning', () => {
+    let fixture: ComponentFixture<PositioningTestComponent>;
+    let comp:    PositioningTestComponent;
+    let overlayContainerElement: HTMLElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          SatPopoverModule,
+          NoopAnimationsModule,
+        ],
+        declarations: [PositioningTestComponent],
+        providers: [
+          {provide: OverlayContainer, useFactory: overlayContainerFactory}
+        ]
+      });
+
+      fixture = TestBed.createComponent(PositioningTestComponent);
+      comp = fixture.componentInstance;
+
+      overlayContainerElement = fixture.debugElement.injector.get(OverlayContainer)
+        .getContainerElement();
+    });
+
+    afterEach(() => {
+      document.body.removeChild(overlayContainerElement);
+    });
+
+    it('should reconstruct the overlay when positions are updated', fakeAsync(() => {
+      fixture.detectChanges();
+
+      // open the overlay and store the overlayRef
+      comp.popover.open();
+      const overlayAfterFirstOpen = comp.anchor._overlayRef;
+
+      comp.popover.close();
+      fixture.detectChanges();
+      tick();
+
+      // change the position and reopen, saving the new overlayRef
+      comp.xPos = 'after';
+      fixture.detectChanges();
+
+      comp.popover.open();
+      const overlayAfterSecondOpen = comp.anchor._overlayRef;
+
+      expect(overlayAfterFirstOpen === overlayAfterSecondOpen).toBe(false);
+    }));
+
+  });
+
 });
 
 /**
@@ -429,6 +480,23 @@ export class KeyboardPopoverTestComponent {
   @ViewChild(SatPopover) popover: SatPopover;
 }
 
+/** This component is for testing dynamic positioning behavior. */
+@Component({
+  template: `
+    <div id="anchor" [satPopoverAnchorFor]="p">Anchor</div>
+
+    <sat-popover #p [xPosition]="xPos" [yPosition]="yPos" [overlapAnchor]="overlap">
+      <div id="content">Popover</div>
+    </sat-popover>
+  `
+})
+export class PositioningTestComponent {
+  @ViewChild(SatPopoverAnchor) anchor: SatPopoverAnchor;
+  @ViewChild(SatPopover) popover: SatPopover;
+  xPos = 'center';
+  yPos = 'center';
+  overlap = true;
+}
 
 /** This factory function provides an overlay container under test control. */
 const overlayContainerFactory = () => {

--- a/src/lib/public_api.ts
+++ b/src/lib/public_api.ts
@@ -1,3 +1,7 @@
-export * from './popover/popover.module';
-export * from './popover/popover.component';
-export * from './popover/popover-anchor.directive';
+export { SatPopoverModule } from './popover/popover.module';
+export { SatPopoverAnchor } from './popover/popover-anchor.directive';
+export {
+  SatPopover,
+  SatPopoverPositionX,
+  SatPopoverPositionY
+} from './popover/popover.component';

--- a/tslint.json
+++ b/tslint.json
@@ -102,18 +102,6 @@
       "check-separator",
       "check-type"
     ],
-    "directive-selector": [
-      true,
-      "attribute",
-      "sat",
-      "camelCase"
-    ],
-    "component-selector": [
-      true,
-      "element",
-      "sat",
-      "kebab-case"
-    ],
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
     "use-life-cycle-interface": true,


### PR DESCRIPTION
Fixes https://github.com/ncsu-sat/popover/issues/46

- Now throws an error if an invalid xPosition or yPosition is provided to the popover.
- Starts a refactor of the demo app to move the examples into their own encapsulated components.