### PR TITLE
feat: allow changing the scroll strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,7 @@ a `mouseleave` event.
 ### Scrolling
 
 By default, when a popover is open and the user scrolls the container, the popover will reposition
-itself to stay attached to its anchor. You can adjust this behavior through the `scrollStrategy`
-api.
+itself to stay attached to its anchor. You can adjust this behavior with `scrollStrategy`.
 
 ```html
 <sat-popover #importantPopover scrollStrategy="block">

--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ If used, the default backdrop will be transparent. You can add any custom backdr
 keep in mind that a backdrop will block pointer events once it is open, immediately triggering
 a `mouseleave` event.
 
+### Scrolling
+
+By default, when a popover is open and the user scrolls the container, the popover will reposition
+itself to stay attached to its anchor. You can adjust this behavior through the `scrollStrategy`
+api.
+
+```html
+<sat-popover #importantPopover scrollStrategy="block">
+  <!-- so important that the user must interact with it -->
+</sat-popover>
+```
+
+| Strategy       | Description
+|----------------|------------------------------------------------
+| `'noop'`       | Don't update position.
+| `'block'`      | Block page scrolling while open.
+| `'reposition'` | Reposition the popover on scroll.
+
 ### Animations
 
 By default, the opening and closing animations of a popover are quick with a simple easing curve.

--- a/src/demo/app/demo.component.ts
+++ b/src/demo/app/demo.component.ts
@@ -12,6 +12,7 @@ import { Component } from '@angular/core';
     <div class="page-content">
       <demo-positioning></demo-positioning>
       <demo-action-api></demo-action-api>
+      <demo-scroll-strategies></demo-scroll-strategies>
       <demo-select-trigger></demo-select-trigger>
       <demo-focus></demo-focus>
       <demo-transitions></demo-transitions>

--- a/src/demo/app/demo.module.ts
+++ b/src/demo/app/demo.module.ts
@@ -18,6 +18,7 @@ import {
 import { DemoComponent } from './demo.component';
 import { PositioningDemo } from './positioning/positioning.component';
 import { ActionAPIDemo } from './action-api/action-api.component';
+import { ScrollStrategiesDemo } from './scroll-strategies/scroll-strategies.component';
 import { SelectTriggerDemo } from './select-trigger/select-trigger.component';
 import { FocusDemo } from './focus/focus.component';
 import { TransitionsDemo } from './transitions/transitions.component';
@@ -43,6 +44,7 @@ export class DemoMaterialModule { }
     DemoComponent,
     PositioningDemo,
     ActionAPIDemo,
+    ScrollStrategiesDemo,
     SelectTriggerDemo,
     FocusDemo,
     TransitionsDemo,

--- a/src/demo/app/scroll-strategies/scroll-strategies.component.scss
+++ b/src/demo/app/scroll-strategies/scroll-strategies.component.scss
@@ -1,0 +1,14 @@
+:host {
+  display: block;
+}
+
+.anchor {
+  margin: 48px;
+}
+
+.popover {
+  padding: 48px;
+  color: white;
+  background: black;
+}
+

--- a/src/demo/app/scroll-strategies/scroll-strategies.component.ts
+++ b/src/demo/app/scroll-strategies/scroll-strategies.component.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'demo-scroll-strategies',
+  styleUrls: ['./scroll-strategies.component.scss'],
+  template: `
+    <mat-card>
+      <mat-card-title>Scroll Strategies</mat-card-title>
+      <mat-card-content>
+        <mat-form-field>
+          <mat-select [(ngModel)]="strategy">
+            <mat-option *ngFor="let option of scrollOptions" [value]="option.value">
+              {{ option.name }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <button mat-raised-button
+            class="anchor"
+            color="primary"
+            [satPopoverAnchorFor]="p"
+            (click)="p.toggle()">
+          TOGGLE
+        </button>
+
+        <sat-popover #p xPosition="after" [overlapAnchor]="false" hasBackdrop>
+          <div class="popover mat-body-1">Scroll the page to observe behavior.</div>
+        </sat-popover>
+
+      </mat-card-content>
+    </mat-card>
+  `
+})
+export class ScrollStrategiesDemo {
+
+  strategy = 'reposition';
+
+  scrollOptions = [
+    { value: 'noop', name: 'Do nothing' },
+    { value: 'close', name: 'Close on scroll' },
+    { value: 'block', name: 'Block scrolling' },
+    { value: 'reposition', name: 'Reposition on scroll' },
+  ];
+}

--- a/src/demo/app/scroll-strategies/scroll-strategies.component.ts
+++ b/src/demo/app/scroll-strategies/scroll-strategies.component.ts
@@ -10,7 +10,7 @@ import { Component } from '@angular/core';
         <mat-form-field>
           <mat-select [(ngModel)]="strategy">
             <mat-option *ngFor="let option of scrollOptions" [value]="option.value">
-              {{ option.name }}
+              {{ option.name }} (<code>{{ option.value }}</code>)
             </mat-option>
           </mat-select>
         </mat-form-field>
@@ -23,7 +23,9 @@ import { Component } from '@angular/core';
           TOGGLE
         </button>
 
-        <sat-popover #p xPosition="after" [overlapAnchor]="false" hasBackdrop>
+        <sat-popover #p xPosition="after" hasBackdrop
+            [overlapAnchor]="false"
+            [scrollStrategy]="strategy">
           <div class="popover mat-body-1">Scroll the page to observe behavior.</div>
         </sat-popover>
 
@@ -40,5 +42,6 @@ export class ScrollStrategiesDemo {
     { value: 'close', name: 'Close on scroll' },
     { value: 'block', name: 'Block scrolling' },
     { value: 'reposition', name: 'Reposition on scroll' },
+    { value: 'rugrats', name: 'Invalid option' },
   ];
 }

--- a/src/demo/app/scroll-strategies/scroll-strategies.component.ts
+++ b/src/demo/app/scroll-strategies/scroll-strategies.component.ts
@@ -38,8 +38,8 @@ export class ScrollStrategiesDemo {
   strategy = 'reposition';
 
   scrollOptions = [
+    // TODO: support close on resolution of https://github.com/angular/material2/issues/7922
     { value: 'noop', name: 'Do nothing' },
-    { value: 'close', name: 'Close on scroll' },
     { value: 'block', name: 'Block scrolling' },
     { value: 'reposition', name: 'Reposition on scroll' },
     { value: 'rugrats', name: 'Invalid option' },

--- a/src/lib/popover/notification.service.ts
+++ b/src/lib/popover/notification.service.ts
@@ -12,6 +12,8 @@ export enum NotificationAction {
   TOGGLE,
   /** Popover has new target positions. */
   REPOSITION,
+  /** Popover needs new configuration. */
+  UPDATE_CONFIG,
 }
 
 /** Event object for dispatching to anchor. */

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -148,6 +148,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
             this.togglePopover();
             break;
           case NotificationAction.REPOSITION:
+          case NotificationAction.UPDATE_CONFIG:
             // TODO: When the overlay's position can be dynamically changed, do not destroy
             this.destroyPopover();
             break;
@@ -196,7 +197,19 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
     config.positionStrategy = this._getPosition();
     config.hasBackdrop = this.attachedPopover.hasBackdrop;
     config.backdropClass = this.attachedPopover.backdropClass || 'cdk-overlay-transparent-backdrop';
-    config.scrollStrategy = this._overlay.scrollStrategies.reposition();
+
+    switch (this.attachedPopover.scrollStrategy) {
+      // TODO support 'close' on resolution of https://github.com/angular/material2/issues/7922
+      case 'block':
+        config.scrollStrategy = this._overlay.scrollStrategies.block();
+        break;
+      case 'reposition':
+        config.scrollStrategy = this._overlay.scrollStrategies.reposition();
+        break;
+      default:
+        config.scrollStrategy = this._overlay.scrollStrategies.noop();
+        break;
+    }
 
     return config;
   }

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -199,7 +199,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
       positionStrategy: this._getPosition(),
       hasBackdrop: this.attachedPopover.hasBackdrop,
       backdropClass: this.attachedPopover.backdropClass || 'cdk-overlay-transparent-backdrop',
-      scrollStrategy: this._getScrollStrategyInstance(this.attachedPopover.scrollStrategy)
+      scrollStrategy: this._getScrollStrategyInstance(this.attachedPopover.scrollStrategy),
     });
 
     return config;

--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -14,7 +14,8 @@ import {
   Overlay,
   OverlayRef,
   OverlayConfig,
-  VerticalConnectionPos
+  ScrollStrategy,
+  VerticalConnectionPos,
 } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { Subject } from 'rxjs/Subject';
@@ -25,7 +26,8 @@ import 'rxjs/add/operator/switchMap';
 import {
   SatPopover,
   SatPopoverPositionX,
-  SatPopoverPositionY
+  SatPopoverPositionY,
+  SatPopoverScrollStrategy,
 } from './popover.component';
 import { NotificationAction, PopoverNotificationService } from './notification.service';
 import { getInvalidPopoverError } from './popover.errors';
@@ -193,23 +195,12 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
 
   /** Create and return a config for creating the overlay. */
   private _getOverlayConfig(): OverlayConfig {
-    const config = new OverlayConfig();
-    config.positionStrategy = this._getPosition();
-    config.hasBackdrop = this.attachedPopover.hasBackdrop;
-    config.backdropClass = this.attachedPopover.backdropClass || 'cdk-overlay-transparent-backdrop';
-
-    switch (this.attachedPopover.scrollStrategy) {
-      // TODO support 'close' on resolution of https://github.com/angular/material2/issues/7922
-      case 'block':
-        config.scrollStrategy = this._overlay.scrollStrategies.block();
-        break;
-      case 'reposition':
-        config.scrollStrategy = this._overlay.scrollStrategies.reposition();
-        break;
-      default:
-        config.scrollStrategy = this._overlay.scrollStrategies.noop();
-        break;
-    }
+    const config = new OverlayConfig({
+      positionStrategy: this._getPosition(),
+      hasBackdrop: this.attachedPopover.hasBackdrop,
+      backdropClass: this.attachedPopover.backdropClass || 'cdk-overlay-transparent-backdrop',
+      scrollStrategy: this._getScrollStrategyInstance(this.attachedPopover.scrollStrategy)
+    });
 
     return config;
   }
@@ -226,6 +217,20 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
         const posY = convertFromVerticalPos(change.connectionPair.overlayY, true);
         this.attachedPopover._setPositionClasses(posX, posY);
       });
+  }
+
+  /** Map a scroll strategy string type to an instance of a scroll strategy. */
+  private _getScrollStrategyInstance(strategy: SatPopoverScrollStrategy): ScrollStrategy {
+    // TODO support 'close' on resolution of https://github.com/angular/material2/issues/7922
+    switch (strategy) {
+      case 'block':
+        return this._overlay.scrollStrategies.block();
+      case 'reposition':
+        return this._overlay.scrollStrategies.reposition();
+      case 'noop':
+      default:
+        return this._overlay.scrollStrategies.noop();
+    }
   }
 
   /** Create and return a position strategy based on config provided to the component instance. */

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -27,14 +27,17 @@ import {
 import {
   getUnanchoredPopoverError,
   getInvalidXPositionError,
-  getInvalidYPositionError
+  getInvalidYPositionError,
+  getInvalidScrollStrategyError,
 } from './popover.errors';
 
 export type SatPopoverPositionX = 'before' | 'center' | 'after';
 export type SatPopoverPositionY = 'above'  | 'center' | 'below';
+export type SatPopoverScrollStrategy = 'noop' | 'close' | 'block' | 'reposition';
 
 export const VALID_POSX: SatPopoverPositionX[] = ['before', 'center', 'after'];
 export const VALID_POSY: SatPopoverPositionY[] = ['above', 'center', 'below'];
+export const VALID_SCROLL: SatPopoverScrollStrategy[] = ['noop', 'close', 'block', 'reposition'];
 
 // See http://cubic-bezier.com/#.25,.8,.25,1 for reference.
 const OPEN_TRANSITION  = '200ms cubic-bezier(0.25, 0.8, 0.25, 1)';
@@ -86,6 +89,18 @@ export class SatPopover implements AfterViewInit {
     }
   }
   private _overlapAnchor = true;
+
+  /** How the popover should handle scrolling. */
+  @Input()
+  get scrollStrategy() { return this._scrollStrategy; }
+  set scrollStrategy(val: SatPopoverScrollStrategy) {
+    this._validateScrollStrategy(val);
+    if (this._scrollStrategy !== val) {
+      this._scrollStrategy = val;
+      // TODO dispatch for re-creation
+    }
+  }
+  private _scrollStrategy: SatPopoverScrollStrategy = 'reposition';
 
   /** Whether the popover should have a backdrop (includes closing on click). */
   @Input()
@@ -260,6 +275,13 @@ export class SatPopover implements AfterViewInit {
   private _validateYPosition(pos: SatPopoverPositionY): void {
     if (VALID_POSY.indexOf(pos) === -1) {
       throw getInvalidYPositionError(pos);
+    }
+  }
+
+  /** Throws an error if the scroll strategy is not a valid strategy. */
+  private _validateScrollStrategy(strategy: SatPopoverScrollStrategy): void {
+    if (VALID_SCROLL.indexOf(strategy) === -1) {
+      throw getInvalidScrollStrategyError(strategy);
     }
   }
 }

--- a/src/lib/popover/popover.component.ts
+++ b/src/lib/popover/popover.component.ts
@@ -33,11 +33,12 @@ import {
 
 export type SatPopoverPositionX = 'before' | 'center' | 'after';
 export type SatPopoverPositionY = 'above'  | 'center' | 'below';
-export type SatPopoverScrollStrategy = 'noop' | 'close' | 'block' | 'reposition';
+// TODO: support close on resolution of https://github.com/angular/material2/issues/7922
+export type SatPopoverScrollStrategy = 'noop' | 'block' | 'reposition';
 
 export const VALID_POSX: SatPopoverPositionX[] = ['before', 'center', 'after'];
 export const VALID_POSY: SatPopoverPositionY[] = ['above', 'center', 'below'];
-export const VALID_SCROLL: SatPopoverScrollStrategy[] = ['noop', 'close', 'block', 'reposition'];
+export const VALID_SCROLL: SatPopoverScrollStrategy[] = ['noop', 'block', 'reposition'];
 
 // See http://cubic-bezier.com/#.25,.8,.25,1 for reference.
 const OPEN_TRANSITION  = '200ms cubic-bezier(0.25, 0.8, 0.25, 1)';
@@ -97,7 +98,7 @@ export class SatPopover implements AfterViewInit {
     this._validateScrollStrategy(val);
     if (this._scrollStrategy !== val) {
       this._scrollStrategy = val;
-      // TODO dispatch for re-creation
+      this._dispatchNotification(new PopoverNotification(NotificationAction.UPDATE_CONFIG));
     }
   }
   private _scrollStrategy: SatPopoverScrollStrategy = 'reposition';

--- a/src/lib/popover/popover.errors.ts
+++ b/src/lib/popover/popover.errors.ts
@@ -1,4 +1,4 @@
-import { VALID_POSX, VALID_POSY } from './popover.component';
+import { VALID_POSX, VALID_POSY, VALID_SCROLL } from './popover.component';
 
 export function getInvalidPopoverError(): Error {
   return Error('SatPopoverAnchor must be provided an SatPopover component instance.');
@@ -9,13 +9,18 @@ export function getUnanchoredPopoverError(): Error {
 }
 
 export function getInvalidXPositionError(pos): Error {
-  const errorString = `Invalid xPosition: '${pos}'. Valid options are ` +
-    `${VALID_POSX.map(x => `'${x}'`).join(', ')}.`;
-  return Error(errorString);
+  return Error(generateGenericError('xPosition', pos, VALID_POSX));
 }
 
 export function getInvalidYPositionError(pos): Error {
-  const errorString = `Invalid yPosition: '${pos}'. Valid options are ` +
-  `${VALID_POSY.map(x => `'${x}'`).join(', ')}.`;
-  return Error(errorString);
+  return Error(generateGenericError('yPosition', pos, VALID_POSY));
+}
+
+export function getInvalidScrollStrategyError(strategy): Error {
+  return Error(generateGenericError('scrollStrategy', strategy, VALID_SCROLL));
+}
+
+function generateGenericError(apiName: string, invalid: string, valid: string[]): string {
+  return `Invalid ${apiName}: '${invalid}'. Valid options are ` +
+    `${valid.map(v => `'${v}'`).join(', ')}.`;
 }

--- a/src/lib/popover/popover.errors.ts
+++ b/src/lib/popover/popover.errors.ts
@@ -20,7 +20,7 @@ export function getInvalidScrollStrategyError(strategy): Error {
   return Error(generateGenericError('scrollStrategy', strategy, VALID_SCROLL));
 }
 
-function generateGenericError(apiName: string, invalid: string, valid: string[]): string {
+function generateGenericError(apiName: string, invalid: any, valid: string[]): string {
   return `Invalid ${apiName}: '${invalid}'. Valid options are ` +
     `${valid.map(v => `'${v}'`).join(', ')}.`;
 }

--- a/src/lib/public_api.ts
+++ b/src/lib/public_api.ts
@@ -3,5 +3,6 @@ export { SatPopoverAnchor } from './popover/popover-anchor.directive';
 export {
   SatPopover,
   SatPopoverPositionX,
-  SatPopoverPositionY
+  SatPopoverPositionY,
+  SatPopoverScrollStrategy,
 } from './popover/popover.component';


### PR DESCRIPTION
Fixes #20 

At the moment, there seems to be something weird with the CloseScrollStrategy. I'm either using it wrong, or it isn't properly detaching. Removed from the possible options for now and tracking at https://github.com/angular/material2/issues/7922.