### PR TITLE
fix: avoid disposing overlay immediately on position or strategy updates

### DIFF
--- a/src/lib/popover/popover-anchor.directive.ts
+++ b/src/lib/popover/popover-anchor.directive.ts
@@ -131,7 +131,7 @@ export class SatPopoverAnchor implements OnInit, OnDestroy {
    * has been closed to destroy it.
    */
   private _destroyPopoverOnceClosed(): void {
-    if (this.isPopoverOpen()) {
+    if (this.isPopoverOpen() && this._overlayRef) {
       this._overlayRef.detachments()
         .take(1)
         .takeUntil(this._onDestroy)

--- a/src/lib/popover/popover.spec.ts
+++ b/src/lib/popover/popover.spec.ts
@@ -503,6 +503,37 @@ describe('SatPopover', () => {
       expect(strategy instanceof BlockScrollStrategy).toBe(true, 'block strategy');
     }));
 
+    it('should wait until the popover is closed to update the strategy', fakeAsync(() => {
+      let strategy;
+      fixture.detectChanges();
+      comp.popover.open();
+
+      // expect it to be open with default strategy
+      strategy = comp.anchor._overlayRef.getConfig().scrollStrategy;
+      expect(strategy instanceof RepositionScrollStrategy).toBe(true, 'reposition strategy');
+      expect(overlayContainerElement.textContent).toContain('Popover', 'initially open');
+
+      // change the strategy while it is open
+      comp.strategy = 'block';
+      fixture.detectChanges();
+      tick();
+
+      // expect it to have remained open with default strategy
+      strategy = comp.anchor._overlayRef.getConfig().scrollStrategy;
+      expect(strategy instanceof RepositionScrollStrategy).toBe(true, 'still reposition strategy');
+      expect(overlayContainerElement.textContent).toContain('Popover', 'Still open');
+
+      // close the popover and reopen
+      comp.popover.close();
+      fixture.detectChanges();
+      tick();
+      comp.popover.open();
+
+      // expect the new strategy to be in place
+      strategy = comp.anchor._overlayRef.getConfig().scrollStrategy;
+      expect(strategy instanceof BlockScrollStrategy).toBe(true, 'block strategy');
+    }));
+
     it('should throw an error when an invalid scrollStrategy is provided', () => {
       fixture.detectChanges();
 

--- a/tools/utils/rollup-globals.js
+++ b/tools/utils/rollup-globals.js
@@ -17,6 +17,8 @@ const GLOBALS = {
   'rxjs/Observable': 'Rx',
   'rxjs/add/operator/takeUntil': 'Rx.Observable.prototype',
   'rxjs/add/operator/switchMap': 'Rx.Observable.prototype',
+  'rxjs/add/operator/take': 'Rx.Observable.prototype',
+  'rxjs/add/observable/merge': 'Rx.Observable',
 };
 
 module.exports = GLOBALS;


### PR DESCRIPTION
Previously, if you updated the position or scroll strategy while the popover was open, it was dispose itself and enter a weird state. This checks if the popover is open before disposing, and if so, it waits until it is detached to dispose of it.